### PR TITLE
Shortcuts Integration

### DIFF
--- a/packages/homekit/ikea/fyrtur.yaml
+++ b/packages/homekit/ikea/fyrtur.yaml
@@ -23,6 +23,13 @@ cover:
     value_template: "{{ value_json.position }}"
     set_position_template: "{ \"position\":{{ position }} }"
 
+  - platform: group
+    name: Covers
+    entities:
+      - cover.ikea_fyrtur
+      - cover.ikea_fyrtur_2
+      - cover.ikea_fyrtur_3
+
 sensor:
   - platform: mqtt
     name: Battery Fyrtur

--- a/packages/homekit/logic/bathroom_occupancy.yaml
+++ b/packages/homekit/logic/bathroom_occupancy.yaml
@@ -45,7 +45,24 @@ automation:
       - service: input_boolean.turn_on
         entity_id: input_boolean.bathroom_occupancy_closed_door
 
-# no motion for 5 minutes -> turn off
+# no motion for 1 minute -> turn off [dim mode]
+  - id: bathroom_occupancy_off
+    alias: Bathroom Occupancy Off
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.xiaomi_motion_sensor_2
+        to: 'off'
+        for:
+          minutes: 1
+    condition:
+      - condition: template
+        value_template: "{{ is_state('input_boolean.dim_mode', 'on') }}"
+    action:
+      - wait_template: "{{ is_state('input_boolean.bathroom_occupancy_closed_door', 'off') }}"
+      - service: input_boolean.turn_off
+        entity_id: input_boolean.bathroom_occupancy
+
+# no motion for 5 minutes -> turn off [not showering]
   - id: bathroom_occupancy_off
     alias: Bathroom Occupancy Off
     trigger:
@@ -54,6 +71,24 @@ automation:
         to: 'off'
         for:
           minutes: 5
+    condition:
+      - condition: template
+        value_template: "{{ states('sensor.xiaomi_humidity_2')|int < 70 }}"
+    action:
+      - wait_template: "{{ is_state('input_boolean.bathroom_occupancy_closed_door', 'off') }}"
+      - service: input_boolean.turn_off
+        entity_id: input_boolean.bathroom_occupancy
+
+# no motion for 10 minutes -> turn off [always]
+  - id: bathroom_occupancy_off
+    alias: Bathroom Occupancy Off
+    trigger:
+      - platform: state
+        entity_id: binary_sensor.xiaomi_motion_sensor_2
+        to: 'off'
+        for:
+          minutes: 10
+    condition:
     action:
       - wait_template: "{{ is_state('input_boolean.bathroom_occupancy_closed_door', 'off') }}"
       - service: input_boolean.turn_off

--- a/packages/other/automations/occupancy.yaml
+++ b/packages/other/automations/occupancy.yaml
@@ -13,27 +13,11 @@ automation:
   - id: turn_dim_mode_on
     alias: Turn Dim Mode On
     trigger:
-      - platform: state
-        entity_id: cover.ikea_fyrtur
-        to: 'closed'
-      - platform: state
-        entity_id: light.ikea_rgbw_bulb
-        to: 'off'
-      - platform: state
-        entity_id: light.ikea_rgbw_bulb_2
-        to: 'off'
-    condition:
-      - condition: state
-        entity_id: cover.ikea_fyrtur
-        state: 'closed'
-      - condition: state
-        entity_id: light.ikea_rgbw_bulb
-        state: 'off'
-      - condition: state
-        entity_id: light.ikea_rgbw_bulb_2
-        state: 'off'
+      - platform: event
+        event_type: shortcut_event
+        event_data:
+          name: bedtime_starts
     action:
-      - wait_template: "{{ is_state('media_player.television', 'off') or is_state('media_player.television', 'unavailable')}}"
       - service: input_boolean.turn_on
         data:
           entity_id: input_boolean.dim_mode
@@ -108,6 +92,7 @@ automation:
       - wait_template: "{{ is_state('binary_sensor.kitchen_occupancy', 'off') }}"
       - service: light.turn_off
         data:
+          transition: 30
           entity_id: light.led_strip
       - wait_template: "{{ is_state('binary_sensor.bathroom_occupancy', 'off') }}"
       - service: input_number.set_value
@@ -137,5 +122,6 @@ automation:
       - wait_template: "{{ is_state('binary_sensor.kitchen_occupancy', 'off') }}"
       - service: light.turn_off
         data:
+          transition: 30
           entity_id: light.ikea_rgbw_bulb_2
 

--- a/packages/other/automations/powernap.yaml
+++ b/packages/other/automations/powernap.yaml
@@ -1,0 +1,26 @@
+automation:
+  - id: powernap_start
+    alias: Powernap Start
+    trigger:
+      - platform: event
+        event_type: shortcut_event
+        event_data:
+          name: powernap
+    action:
+      - delay:
+          minutes: "{{ trigger.event.data.length }}"
+      - service: cover.open_cover
+        entity_id: cover.covers
+
+  - id: powernap_stop
+    alias: Powernap Stop
+    trigger:
+      - platform: event
+        event_type: shortcut_event
+        event_data:
+          name: do_not_disturb_off
+    action:
+      - service: automation.turn_off
+        entity_id: automation.powernap_start
+      - service: automation.turn_on
+        entity_id: automation.powernap_start

--- a/packages/other/ios.yaml
+++ b/packages/other/ios.yaml
@@ -25,7 +25,9 @@ automation:
     alias: iPhone Start Charging
     trigger: 
       - platform: event
-        event_type: ios_charger_connected
+        event_type: shortcut_event
+        event_data:
+          name: charger_connected
     action:
       - service: input_boolean.turn_on
         data:
@@ -36,9 +38,35 @@ automation:
     alias: iPhone Stop Charging
     trigger: 
       - platform: event
-        event_type: ios_charger_disconnected
+        event_type: shortcut_event
+        event_data:
+          name: charger_disconnected 
     action:
       - service: input_boolean.turn_off
         data:
           entity_id: input_boolean.iphone_charging
-      
+
+  - id: start_do_not_disturb
+    alias: Start Do Not Disturb
+    trigger:
+      - platform: event
+        event_type: shortcut_event
+        event_data:
+          name: do_not_disturb_on
+    action:
+      - service: input_boolean.turn_on
+        data:
+          entity_id: input_boolean.do_not_disturb
+
+
+  - id: stop_do_not_disturb
+    alias: Stop Do Not Disturb
+    trigger: 
+      - platform: event
+        event_type: shortcut_event
+        event_data:
+          name: do_not_disturb_off
+    action:
+      - service: input_boolean.turn_off
+        data:
+          entity_id: input_boolean.do_not_disturb


### PR DESCRIPTION
iOS Shortcuts can fire events through the Home Assistant app.
These are used to create HA sensors for iOS charging and DND.
